### PR TITLE
games-rpg/torchlight: Add missing libglut.so.3 dep

### DIFF
--- a/games-rpg/torchlight/torchlight-1.15.20130521.ebuild
+++ b/games-rpg/torchlight/torchlight-1.15.20130521.ebuild
@@ -83,7 +83,8 @@ src_unpack() {
 			"deps/fmod/fmod_files_linux_${arch}" \
 			"deps/pcre/pcre_files_linux_${arch}" \
 			"deps/SDL2/SDL2_files_linux_${arch}" \
-			"deps/CEGUI/CEGUI_files_linux_${arch}"
+			"deps/CEGUI/CEGUI_files_linux_${arch}" \
+			"deps/GLUT/GLUT_files_linux_${arch}"
 	# We just installed some crap to avoid broken depends
 }
 


### PR DESCRIPTION
Tested using an `~amd64` system. The missing `libglut.so.3` dependency can be met either with the bundled library (which I added to follow suit), or with the `media-libs/freeglut` package. I was unsure which method would be preferred, so I opted to include the bundled version to ensure compatibility. Verified working on my end.